### PR TITLE
(hotfix): base_manager_name should be 'objects'

### DIFF
--- a/django_serializable_model.py
+++ b/django_serializable_model.py
@@ -47,7 +47,7 @@ class SerializableModel(models.Model):
     class Meta:
         abstract = True
         # when queried from a related Model, use this Manager
-        base_manager_name = 'SerializableManager'
+        base_manager_name = 'objects'
 
     def serialize(self, *args, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='django-serializable-model',
-    version='0.0.4',
+    version='0.0.5-alpha.1',
     description=('Django classes to make your models, managers, and ' +
                  'querysets serializable, with built-in support for related ' +
                  'objects in ~100 LoC'),


### PR DESCRIPTION
- (hotfix): base_manager_name should be 'objects'
- (pub): publish v0.0.5-alpha.1

Should resolve #4 . Using [SemVer naming scheme for pre-release](https://semver.org/#spec-item-9) that isn't _favored_ by [PEP 440](https://www.python.org/dev/peps/pep-0440/#pre-release-separators) but is compatible. Adding the publish commit as I'll release this quickly with just one commit in it as it's an alpha.