### PR TITLE
(env): use poetry 1.0.0b3 which fixes multi-constraint deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ matrix:
   include:
     # Python 3.x envs
     - env: DJANGO_VERSION=2.2
+      install: poetry install  # no need to override Django, this is default
+
     - env: DJANGO_VERSION=1.9
+
     - env: DJANGO_VERSION=1.5
       python: '3.4'  # Python 3.5+ will error on Django < 1.8: https://stackoverflow.com/a/36000103/3431180
-      # Poetry fails to resolve multi-constrant deps, so don't use it (https://github.com/sdispater/poetry/issues/666#issuecomment-531100022)
+      # Poetry can't specify constraints that rely on other deps
       before_install: skip
       install:
         # django 1.5 needs pytest-django 2.9 needs pytest 3.5 needs pytest-cov 2.6
@@ -19,16 +22,9 @@ matrix:
     # Python 2.7 envs
     - env: DJANGO_VERSION=1.11  # latest Django that supports 2.7
       python: '2.7'
-      # Poetry fails to resolve multi-constrant deps, so don't use it (https://github.com/sdispater/poetry/issues/666#issuecomment-531100022)
-      before_install: skip
-      install:
-        # pytest 5+ does not support Python 2.7
-        - pip install django==1.11 "pytest<5" pytest-django pytest-cov
-        - rm pyproject.toml  # editable install reads from here somehow and bugs out on 2.7!!??!!: https://travis-ci.org/agilgur5/django-serializable-model/jobs/584822609
-        - pip install -e .  # won't be able to do this if setup.py is removed!
 
 
-before_install: pip install poetry
+before_install: pip install "poetry>=1.0.0b3"
 install:
   - poetry install
   # override the version for each test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,14 +64,20 @@ keywords=[
 "Tracker" = "https://github.com/agilgur5/django-serializable-model/issues"
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^2.7 || ^3.5"
 
 [tool.poetry.dev-dependencies]
-django = "^2.2"
-pytest = "^5.1"
+django = [
+    {version = "^2.2", python = "^3.5"},
+    {version = "^1.11", python = "^2.7"}
+]
+pytest = [
+    {version = "^5.1", python = "^3.5"},
+    {version = "<5", python = "^2.7"}
+]
 pytest-django = "^3.5"
 pytest-cov = "^2.7"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0.0b3"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
- can now specify multiple versions of devDeps that specify different
  versions of Python

- use this to simplify matrix testing for Python 2.7

See also #6 which ran into this issue, and my comment in https://github.com/sdispater/poetry/issues/666#issuecomment-531100022 about this, as well as the issue that duplicates it in https://github.com/sdispater/poetry/issues/1480, the PR that fixes it in https://github.com/sdispater/poetry/issues/1482, and my PR that apparently duplicated the failing tests there in https://github.com/sdispater/poetry/pull/1509